### PR TITLE
Handle calling of 'class' instance

### DIFF
--- a/curry.py
+++ b/curry.py
@@ -1,10 +1,13 @@
-from inspect import signature
+from inspect import signature, isclass
 import sys
 import unittest
 
 
 def curry(fun):
-    arg_count = len(signature(fun).parameters)
+    if isclass(fun):
+        arg_count = len(signature(fun.__call__).parameters)
+    else:
+        arg_count = len(signature(fun).parameters)
 
     def curried(*old_args, **old_kwargs):
         args_store = list(old_args)


### PR DESCRIPTION
Builtins (like `map` or `filter`), by default, refer to their class rather than their function call. This caused `test_builtin` to fail.

For the above builtins, referring to their `__call__` instance allows them to operate as any other function when curried.