### PR TITLE
add a couple of tests - one good one bad

### DIFF
--- a/test_curry.py
+++ b/test_curry.py
@@ -50,5 +50,31 @@ class CurryTest(unittest.TestCase):
         self.assertEqual('add', add.__name__)
         self.assertEqual('add', add(1).__name__)
 
+    def test_twice(self):
+        times = curry(lambda x, y: x * y)
+        plus = curry(lambda x, y: x + y)
+
+        self.assertEqual(times(3)(times(4)(2)), 24)
+        self.assertEqual(times(5)(times(4)(2)), 40)
+
+        triple = times(3)
+        self.assertEqual(triple(6), 18)
+        triple = times(3)
+        self.assertEqual(triple(20), 60)
+
+        triple = times(3)
+        self.assertEqual(triple(6), 18)
+        self.assertEqual(triple(20), 60)
+
+    def test_embrace(self):
+        def generalEmbrace (prefix, suffix, str):
+            return prefix + str + suffix
+
+        brace = curry(lambda str: generalEmbrace('{', '}', str))
+        bracket = curry(lambda str: generalEmbrace('[', ']', str))
+
+        self.assertEqual(brace("Curry"), "{Curry}");
+        self.assertEqual(bracket("Curry"), "[Curry]");
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi,

This is first for me (not just first Hacktoberfest but first pull request on GitHub or anywhere for that matter).  I hope I have got the mechanics right.

I have added two tests.  The first test fails and the failure has stopped me adding the test cases I wanted to submit.

I was hoping to build tests that defined a polynomial function as a series of SMID operations but ran into a problem trying to evaluate the polynomial more than once.  Not a lot of use if you want to, say, plot the polynomial.

I know that purists would insist only one assertion per test case but if I did that it would not be possible to demonstrate the issue.

The assignment:
```python
    triple = times(3)
```
seems quite legitimate to me and it works BUT only once for each assignment.   I guess that is not what what intended and it is inconvenient either way.

It seems to mean I can curry functions but cannot then use them to compose more complex functions.  I know my understanding of Functional Programming is not all that it could be but the texts I have read seem to think currying and composition are two sides of the same coin so I hope I will be possible to revise your curry decorator so that _triple_, for example, may be assigned once and then used many times over.
