### PR TITLE
Add tests catching persistency issue. Present possible reimplementation.

### DIFF
--- a/test_curry.py
+++ b/test_curry.py
@@ -23,6 +23,20 @@ class CurryTest(unittest.TestCase):
         self.assertEqual(2, add1(1))
         self.assertEqual(3, add2(1))
 
+    def test_args_dont_persist_after_first(self):
+        factory = curry(lambda a, b, c: None)
+        curried = factory(1)
+        given_b = curried(2)
+        given_c = curried(3)
+        self.assertIsNotNone(given_c)
+
+    def test_kwargs_dont_persist(self):
+        factory = curry(lambda a=None, b=None, c=None: None)
+        curried = factory(a=None)
+        given_b = curried(b=None)
+        given_c = curried(c=None)
+        self.assertIsNotNone(given_c)
+
     def test_mutable_args(self):
         def concat(a, b):
             ret = []


### PR DESCRIPTION
The first issue was that `kwargs_store` was updated in place in [`curried`](https://github.com/chrfrasco/curry.py/blob/6ba0d8b6f299ed49847ce5905f339691a4ab726d/curry.py#L32). This was comparable to updating the positional arguments with `args_store.extend(args)` rather than `args_store = args_store + args`. Unfortunately, I believe that copying the keyword arguments, so that `id(kwargs_store)` would (like `id(args_store)`) change when `curried` was called would not fix the fundamental issue, which is (if I understand correctly) that all the curried functions share the same closure. I ran the following on `master`:

```python
>>> f = curry(lambda a, b, c, d: None)
>>> a = f(None)
>>> b1 = a('first value for b')
>>> b2 = a('second value for b')
>>> a.__closure__ is b1.__closure__ is b2.__closure__
True
>>> for cell in a.__closure__:
...     print(cell, cell.cell_contents)
<cell at 0x7fec51f87258: int object at 0x56350f737da0> 4
<cell at 0x7fec51e6ecd8: list object at 0x7fec51b7c6c8> [None, 'first value for b', 'second value for b']
<cell at 0x7fec51e5c4f8: function object at 0x7fec51b83840> <function <lambda> at 0x7fec51b83840>
<cell at 0x7fec51e6ec48: function object at 0x7fec51f93048> <function <lambda> at 0x7fec51f93048>
<cell at 0x7fec51bbf408: dict object at 0x7fec51e83a08> {}

```

The second commit reimplements `curry` using a class to avoid this. No need to merge that change; I'd like to see a fix using only functions! Maybe `curried` could somehow return a copy of itself with a new closure.