### PR TITLE
Another take on handling defaults

### DIFF
--- a/curry.py
+++ b/curry.py
@@ -3,7 +3,6 @@
 from functools import wraps
 from inspect import signature, isbuiltin, isclass
 
-
 def curry(func, args=None, kwargs=None, n=None):
     if not callable(func):
         raise TypeError('first argument must be callable')
@@ -14,7 +13,7 @@ def curry(func, args=None, kwargs=None, n=None):
     @wraps(func)
     def curried(*new_args, **new_kwargs):
         next_args = args + new_args
-        
+
         next_kwargs = kwargs.copy()
         next_kwargs.update(new_kwargs)
 
@@ -24,13 +23,45 @@ def curry(func, args=None, kwargs=None, n=None):
             return func(*next_args, **next_kwargs)
 
         return curry(func, args=next_args, kwargs=next_kwargs, n=n)
-    
+
     return curried
 
+def curry_default(func, args=None, kwargs=None, n=None):
+    if not callable(func):
+        raise TypeError('first argument must be callable')
+
+    args = args if args is not None else tuple()
+    kwargs = kwargs if kwargs is not None else dict()
+
+    @wraps(func)
+    def curried(*new_args, **new_kwargs):
+        next_args = args + new_args
+
+        next_kwargs = kwargs.copy()
+        next_kwargs.update(new_kwargs)
+
+        target_arg_count = n if n is not None else get_target_arg_count(func)
+        default_count = count_defaults(func)
+
+        if current_count(next_args, next_kwargs) == target_arg_count:
+            return func(*next_args, **next_kwargs)
+        elif current_count(next_args, next_kwargs) == target_arg_count - default_count:
+            return func(*next_args, **next_kwargs)
+
+        return curry_default(func, args=next_args, kwargs=next_kwargs, n=n)
+
+    return curried
 
 def current_count(next_args, next_kwargs):
     return len(next_args) + len(next_kwargs)
 
+def count_defaults(func):
+    length = 0
+    if func.__defaults__ is not None:
+        length += len(func.__defaults__)
+    if func.__kwdefaults__ is not None:
+        length += len(func.__kwdefaults__)
+    return length
 
 def get_target_arg_count(func):
     if isclass(func) or isbuiltin(func):
@@ -39,4 +70,3 @@ def get_target_arg_count(func):
 
     sig = signature(func)
     return len(sig.parameters)
-

--- a/test_curry.py
+++ b/test_curry.py
@@ -1,12 +1,15 @@
 import math
 import unittest
-from curry import curry
+from curry import curry, curry_default
 
 def func(a, b, *, c, d):
     return (a, b), dict(c=c, d=d)
 
 
 def add(a, b):
+    return a + b
+
+def add_default(a, b=10):
     return a + b
 
 
@@ -78,11 +81,17 @@ class TestCurry(unittest.TestCase):
 
         add_arity_2 = curry(sum_, n=2)
         self.assertEqual(add_arity_2(10, 10), 20)
+        self.assertEqual(curry_default(sum_, n=2)(10, 10), 20)
 
         add_ten = add_arity_2(10)
         self.assertEqual(add_ten(10), 20)
 
+    def test_defaults(self):
+
+        self.assertEqual(curry_default(add_default)(20), 30)
+        self.assertEqual(curry_default(add_default)(20, 20), 40)
+        self.assertRaises(TypeError, curry_default(add_default), {20, 40})
+
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Another take on handling defaults with curry -- adding a separate decorator called `curry_default` to evaluate the function once it hits keyword arguments.

Added some tests; example usage:

```
>>> from curry import curry, curry_default

>>> @curry_default
>>> def add_default(a, b=10):
>>>     return a + b

>>> @curry
>>> def add_no_default(a, b=10):
>>>     return a + b

>>> print(add_default(20))
30
>>> print(add_default(20, 10))
30
>>> print(add_default())
<function add_default at 0x107f2e730>

>>> print(add_no_default(20))
<function add_default at 0x107f2e730>
>>> print(add_no_default(20, 10))
30
>>> print(add_no_default())
<function add_no_default at 0x107f2e730>

```